### PR TITLE
[Feature] Support to verify the specified claims fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ BUILD_DEPS = emqx cuttlefish
 dep_emqx = git-emqx https://github.com/emqx/emqx $(BRANCH)
 dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.2.1
 
+TEST_DEPS = emqx_ct_helper
+dep_emqx_ct_helper = git-emqx https://github.com/emqx/emqx-ct-helpers $(BRANCH)
 
 ERLC_OPTS += +debug_info
 

--- a/README.md
+++ b/README.md
@@ -19,26 +19,33 @@ File: etc/plugins/emqx_auth_jwt.conf
 ## HMAC Hash Secret.
 ##
 ## Value: String
-auth.jwt.secret = emqsecret
+auth.jwt.secret = emqxsecret
+
+## From where the JWT string can be got
+##
+## Value: username | password
+## Default: password
+auth.jwt.from = password
 
 ## RSA or ECDSA public key file.
 ##
 ## Value: File
 ## auth.jwt.pubkey = etc/certs/jwt_public_key.pem
 
-## Whether to open payload validation
+## Enable to verify claims fields
 ##
 ## Value: on | off
-auth.jwt.verify_payload = off
+auth.jwt.verify_claims = off
 
-## Verify payload content configuration information
+## The checklist of claims to validate
 ##
 ## Value: String
-## auth.jwt.verify_payload.$sub = %c
-## auth.jwt.verify_payload.$name = %u
-## auth.jwt.verify_payload.$name = secret
-
-
+## auth.jwt.verify_claims.$name = expected
+##
+## Variables:
+##  - %u: username
+##  - %c: clientid
+# auth.jwt.verify_claims.username = %u
 ```
 
 Load the Plugin

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ auth.jwt.secret = emqsecret
 ##
 ## Value: File
 ## auth.jwt.pubkey = etc/certs/jwt_public_key.pem
+
+## Whether to open payload validation
+##
+## Value: on | off
+auth.jwt.verify_payload = off
+
+## Verify payload content configuration information
+##
+## Value: String
+## auth.jwt.verify_payload.$sub = %c
+## auth.jwt.verify_payload.$name = %u
+## auth.jwt.verify_payload.$name = secret
+
+
 ```
 
 Load the Plugin

--- a/etc/emqx_auth_jwt.conf
+++ b/etc/emqx_auth_jwt.conf
@@ -18,24 +18,17 @@ auth.jwt.from = password
 ## Value: File
 ## auth.jwt.pubkey = etc/certs/jwt_public_key.pem
 
-## Whether to open payload validation
+## Enable to verify claims fields
 ##
 ## Value: on | off
-auth.jwt.verify_payload = off
+auth.jwt.verify_claims = off
 
-## Verify payload content configuration information
+## The checklist of claims to validate
 ##
 ## Value: String
-## auth.jwt.verify_payload.$sub = %c
-## auth.jwt.verify_payload.$name = %u
-## auth.jwt.verify_payload.$name = secret
-## Description：
-## %c: Payload and clientid will be validated
-## %u: Payload and username will be validated
-## secret: User-defined validation values
+## auth.jwt.verify_claims.$name = expected
 ##
-## For example
-#auth.jwt.verify_payload.sub = %c
-#auth.jwt.verify_payload.name = secret
-#auth.jwt.verify_payload.sub = %c
-#auth.jwt.verify_payload.sub = %u
+## Variables:
+##  - %u: username
+##  - %c: clientid
+# auth.jwt.verify_claims.username = %u

--- a/etc/emqx_auth_jwt.conf
+++ b/etc/emqx_auth_jwt.conf
@@ -18,3 +18,24 @@ auth.jwt.from = password
 ## Value: File
 ## auth.jwt.pubkey = etc/certs/jwt_public_key.pem
 
+## Whether to open payload validation
+##
+## Value: on | off
+auth.jwt.verify_payload = off
+
+## Verify payload content configuration information
+##
+## Value: String
+## auth.jwt.verify_payload.$sub = %c
+## auth.jwt.verify_payload.$name = %u
+## auth.jwt.verify_payload.$name = secret
+## Description：
+## %c: Payload and clientid will be validated
+## %u: Payload and username will be validated
+## secret: User-defined validation values
+##
+## For example
+#auth.jwt.verify_payload.sub = %c
+#auth.jwt.verify_payload.name = secret
+#auth.jwt.verify_payload.sub = %c
+#auth.jwt.verify_payload.sub = %u

--- a/priv/emqx_auth_jwt.schema
+++ b/priv/emqx_auth_jwt.schema
@@ -37,7 +37,7 @@
                               [{list_to_atom(Name), list_to_binary(Value)} | Acc];
                           ({["auth","jwt","verify_payload"], Value}, Acc) ->
                               Acc
-                      end,
+                       end,
                       [], cuttlefish_variable:filter_by_prefix("auth.jwt.verify_payload", Conf))
-  end
+   end
 end}.

--- a/priv/emqx_auth_jwt.schema
+++ b/priv/emqx_auth_jwt.schema
@@ -17,3 +17,27 @@
   {datatype, string}
 ]}.
 
+%% Whether to open payload validation
+{mapping, "auth.jwt.verify_payload", "emqx_auth_jwt.verify_payload", [
+  {default, off},
+  {datatype, flag}
+]}.
+
+%% Verify payload content configuration information
+{mapping, "auth.jwt.verify_payload.$name", "emqx_auth_jwt.verify_payload", [
+  {datatype, string}
+]}.
+
+{translation, "emqx_auth_jwt.verify_payload", fun(Conf) ->
+   case cuttlefish:conf_get("auth.jwt.verify_payload", Conf) of
+    false -> cuttlefish:unset();
+    true  ->
+            lists:foldl(
+                       fun({["auth","jwt","verify_payload", Name], Value}, Acc) ->
+                              [{list_to_atom(Name), list_to_binary(Value)} | Acc];
+                          ({["auth","jwt","verify_payload"], Value}, Acc) ->
+                              Acc
+                      end,
+                      [], cuttlefish_variable:filter_by_prefix("auth.jwt.verify_payload", Conf))
+  end
+end}.

--- a/priv/emqx_auth_jwt.schema
+++ b/priv/emqx_auth_jwt.schema
@@ -1,8 +1,5 @@
-%%-------------------------------------------------------------------
-%% JWT Auth Plugin
-%%-------------------------------------------------------------------
+%%-*- mode: erlang -*-
 
-%% HMAC hash Secret
 {mapping, "auth.jwt.secret", "emqx_auth_jwt.secret", [
   {datatype, string}
 ]}.
@@ -12,32 +9,29 @@
   {datatype, atom}
 ]}.
 
-%% RSA or ECDSA public key file
 {mapping, "auth.jwt.pubkey", "emqx_auth_jwt.pubkey", [
   {datatype, string}
 ]}.
 
-%% Whether to open payload validation
-{mapping, "auth.jwt.verify_payload", "emqx_auth_jwt.verify_payload", [
+{mapping, "auth.jwt.verify_claims", "emqx_auth_jwt.verify_claims", [
   {default, off},
   {datatype, flag}
 ]}.
 
-%% Verify payload content configuration information
-{mapping, "auth.jwt.verify_payload.$name", "emqx_auth_jwt.verify_payload", [
+{mapping, "auth.jwt.verify_claims.$name", "emqx_auth_jwt.verify_claims", [
   {datatype, string}
 ]}.
 
-{translation, "emqx_auth_jwt.verify_payload", fun(Conf) ->
-   case cuttlefish:conf_get("auth.jwt.verify_payload", Conf) of
-    false -> cuttlefish:unset();
-    true  ->
-            lists:foldl(
-                       fun({["auth","jwt","verify_payload", Name], Value}, Acc) ->
-                              [{list_to_atom(Name), list_to_binary(Value)} | Acc];
-                          ({["auth","jwt","verify_payload"], Value}, Acc) ->
-                              Acc
-                       end,
-                      [], cuttlefish_variable:filter_by_prefix("auth.jwt.verify_payload", Conf))
+{translation, "emqx_auth_jwt.verify_claims", fun(Conf) ->
+    case cuttlefish:conf_get("auth.jwt.verify_claims", Conf) of
+        false -> cuttlefish:unset();
+        true ->
+            lists:foldr(
+              fun({["auth","jwt","verify_claims", Name], Value}, Acc) ->
+                      [{list_to_atom(Name), list_to_binary(Value)} | Acc];
+                 ({["auth","jwt","verify_claims"], _Value}, Acc) ->
+                      Acc
+              end, [], cuttlefish_variable:filter_by_prefix("auth.jwt.verify_claims", Conf))
    end
 end}.
+

--- a/src/emqx_auth_jwt_app.erl
+++ b/src/emqx_auth_jwt_app.erl
@@ -15,11 +15,13 @@
 -module(emqx_auth_jwt_app).
 
 -behaviour(application).
+
 -behaviour(supervisor).
 
 -emqx_plugin(?MODULE).
 
 -export([start/2, stop/1]).
+
 -export([init/1]).
 
 -define(APP, emqx_auth_jwt).
@@ -47,15 +49,19 @@ init([]) ->
 %%--------------------------------------------------------------------
 
 auth_env() ->
-    #{secret => application:get_env(?APP, secret, undefined),
-      from => application:get_env(?APP, from, password),
-      pubkey => read_pubkey(),
-      verify_payload => application:get_env(?APP, verify_payload, undefined)}.
+    #{ secret => env(secret, undefined)
+     , from => env(from, password)
+     , pubkey => read_pubkey()
+     , checklists => env(verify_claims, [])
+     }.
 
 read_pubkey() ->
-    case application:get_env(?APP, pubkey) of
+    case env(pubkey, undefined) of
         undefined  -> undefined;
-        {ok, Path} -> {ok, PubKey} = file:read_file(Path),
-                      PubKey
+        {ok, Path} ->
+            {ok, PubKey} = file:read_file(Path), PubKey
     end.
+
+env(Key, Default) ->
+    application:get_env(?APP, Key, Default).
 

--- a/src/emqx_auth_jwt_app.erl
+++ b/src/emqx_auth_jwt_app.erl
@@ -49,7 +49,8 @@ init([]) ->
 auth_env() ->
     #{secret => application:get_env(?APP, secret, undefined),
       from => application:get_env(?APP, from, password),
-      pubkey => read_pubkey()}.
+      pubkey => read_pubkey(),
+      verify_payload => application:get_env(?APP, verify_payload, undefined)}.
 
 read_pubkey() ->
     case application:get_env(?APP, pubkey) of


### PR DESCRIPTION
Hello there, the JWT plugin can now verify the specified JWT claims.

Set `auth.jwt.verify_claims = on` to enable verify some specified fields:

```properties
# Enable verifying claims fields
auth.jwt.verify_claims = on

## Specify the `sub` claim must be equal to string "87891246"
auth.jwt.verify_claims.sub = 87891246

## Specify the `username` claim must be equal to string "user1"
auth.jwt.verify_claims.username = user1

## It also supports placeholders from MQTT CONNECT packet
## - %u: username
## - %c: password
##
## e.g. to specify the `username` claim must be equal to string "{{mqtt-username}}":
##        auth.jwt.verify_claims.username = %u
##
## i.e. If the username got from MQTT CONNECT is "user1", then the 'username' claim
##        must be equal to "user1"

```